### PR TITLE
Fix: fitAllTabs mode now does not ignore custom tab background color

### DIFF
--- a/ViewPager-Swift/Core/ViewPagerTabView.swift
+++ b/ViewPager-Swift/Core/ViewPagerTabView.swift
@@ -70,6 +70,7 @@ public final class ViewPagerTabView: UIView {
             
             buildTitleLabel(withOptions: options, text: tab.title)
             titleLabel?.frame = CGRect(x: 0, y: 0, width: self.frame.size.width, height: self.frame.size.height)
+            titleLabel?.backgroundColor = tab.color
             
         case .distributeNormally:
             


### PR DESCRIPTION
I found an issue where if you're using custom background colors for each ViewPagerTab, and are using the library in **fitAllTabs** mode, the custom colors are ignored. I fixed this issue in this PR.